### PR TITLE
Add missing localisation label for footer menu label

### DIFF
--- a/locale/de/locale.po
+++ b/locale/de/locale.po
@@ -382,8 +382,11 @@ msgstr "Hintergrundfarbe der Fußzeile"
 msgid "plugins.themes.individualizeTheme.option.footerTextColor.label"
 msgstr "Textfarbe der Fußzeile"
 
+msgid "plugins.themes.individualizeTheme.option.footerMenu.label"
+msgstr "Menüs in der Fußzeile anzeigen"
+
 msgid "plugins.themes.individualizeTheme.option.footerMenu.checkbox"
-msgstr "Ja, zeige die navigationsmenüs im Footer jeder Seite an."
+msgstr "Ja, zeige die Navigationsmenüs im Footer jeder Seite an."
 
 msgid "plugins.themes.individualizeTheme.option.articleFullText.label"
 msgstr "Artikel HTML Volltext"


### PR DESCRIPTION
I've just stumbled across a missing label in the German localisation. No big deal. Perhaps the adjustment will find its way into the product with one of the next updates.

BTW: Great work! I like the many options and the good integration of web fonts via the Google Font plugin. 👍